### PR TITLE
[/] 1.6 Update + New base mod alternative

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -9,6 +9,7 @@
 		<li>1.3</li>
 		<li>1.4</li>
 		<li>1.5</li>
+		<li>1.6</li>
 	</supportedVersions>
 	<packageId>Garethp.ReplaceStuffCompatibility</packageId>
 	<description>A patch for Replace Stuff to introduce compatibility for various mods. Replace ship walls and reactors without having to remove them first. Source code found on [url=https://github.com/Garethp/replace-stuff-compatibility]Github[/url]
@@ -143,6 +144,7 @@ Mods included in this patch so far are:
 		</li>
 		<li>
 			<packageId>Uuugggg.ReplaceStuff</packageId>
+			<alternativePackageIds><li>memegoddess.replacestuff</li></alternativePackageIds>
 			<displayName>Replace Stuff</displayName>
 			<steamWorkshopUrl>https://steamcommunity.com/id/Uuugggg/myworkshopfiles/?appid=294100</steamWorkshopUrl>
 		</li>
@@ -150,6 +152,7 @@ Mods included in this patch so far are:
 	
 	<loadAfter>
 		<li>Uuugggg.ReplaceStuff</li>
+		<li>memegoddess.replacestuff</li>
 		<li>kentington.saveourship2</li>
 		<li>vanillaexpanded.vfecore</li>
 		<li>khamenman.armorracks</li>

--- a/Defs/VanillaExpandedSpacer.xml
+++ b/Defs/VanillaExpandedSpacer.xml
@@ -19,7 +19,7 @@
 			<li>
 				<category>Lights</category>
 				<items>
-					<li>Light_SpacerLamp</li>
+					<!-- No longer exists <li>Light_SpacerLamp</li> -->
 					<li>Spacer_OutdoorLamp</li>
 				</items>
 			</li>

--- a/Defs/VanillaFurnitureExpanded.xml
+++ b/Defs/VanillaFurnitureExpanded.xml
@@ -12,7 +12,7 @@
 			<li>
 				<category>EndTables</category>
 				<items>
-					<li>Table_LightEndTable</li>
+					<!-- No longer exists <li>Table_LightEndTable</li> -->
 					<li>Table_RoyalEndTable</li>
 				</items>
 			</li>
@@ -28,7 +28,7 @@
 				<category>Lights</category>
 				<items>
 					<li>Light_Streetlamp</li>
-					<li>Table_LightEndTable</li>
+					<!-- No longer exists <li>Table_LightEndTable</li> -->
 				</items>
 			</li>
 			

--- a/Modlist.xml
+++ b/Modlist.xml
@@ -6,6 +6,7 @@
     <li>ludeon.rimworld.royalty</li>
     <li>ludeon.rimworld.ideology</li>
 		<li>uuugggg.replacestuff</li>
+    <li>memegoddess.replacestuff</li>
 	  <li>garethp.replacestuffcompatibility</li>
     <li>nightmare.jaxe.publisherplusmultiversionfork</li>
   </activeMods>

--- a/Patches/SimpleUtilitiesWall.xml
+++ b/Patches/SimpleUtilitiesWall.xml
@@ -6,7 +6,7 @@
 			<li Class="PatchOperationReplace">
 				<success>Always</success>
 				<xpath>
-					/Defs/ThingDef[defName="Vent" or defName="Cooler"]/comps/li[@Class="VanillaFurnitureExpanded.CompProperties_MountableOnWall"]
+					/Defs/ThingDef[defName="Vent" or defName="Cooler"]/comps/li[@Class="VEF.Buildings.CompProperties_MountableOnWall"]
 				</xpath>
 				<value>
 					<li Class="Replace_Stuff_Compatibility.Comps.CompProperties_MountableOnWall"/>

--- a/Patches/VanillaFurnitureExpandedWallMountable.xml
+++ b/Patches/VanillaFurnitureExpandedWallMountable.xml
@@ -6,7 +6,7 @@
 			<li Class="PatchOperationReplace">
 				<success>Always</success>
 				<xpath>
-					/Defs/ThingDef/comps/li[@Class="VanillaFurnitureExpanded.CompProperties_MountableOnWall" or @Class="MURWallLight.CompProperties_AttachableToWall"]
+					/Defs/ThingDef/comps/li[@Class="VEF.Buildings.CompProperties_MountableOnWall" or @Class="MURWallLight.CompProperties_AttachableToWall"]
 				</xpath>
 				<value>
 					<li Class="Replace_Stuff_Compatibility.Comps.CompProperties_MountableOnWall"/>


### PR DESCRIPTION
- Changes to About.xml to support both 1.6 RimWorld version + alternative for the Replace Stuff Mod;
- Removed 2 items from Vanilla Furniture Expanded/Spacer as they no longer exists;
- Changed the Class from the VE Framework to the new one;
OBS: Things to note are that I didn't add the new items to be replaced that were added on Vanilla Furniture Expanded, I wasn't able to test all the mods like SOS2 and only a Table and Plant Grower didn't get deconstructed, only uninstalled (minified), couldn't find the reason why.